### PR TITLE
Jess/remove exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@
 # PROJECT COMMANDS:
 
 # 1
-To start the project run:
+To start the project on a Linux run:
 `bash create-vm.sh`
+To start the project on a Mac run:
+`zsh create-vm.sh`
+
 
 # 2
 To transfer file from local to vm, cd to Project-AWS and run the following command:

--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@
 # PROJECT COMMANDS:
 
 # 1
-To start the project on a Linux run:
-`bash create-vm.sh`
-To start the project on a Mac run:
-`zsh create-vm.sh`
+To start the project run:
+`$SHELL create-vm.sh`
 
 
 # 2

--- a/TFInstall.sh
+++ b/TFInstall.sh
@@ -21,6 +21,6 @@ if dpkg -s software-properties-common > /dev/null 2>&1; then
   echo 'software-properties-common is already installed'
 else
   echo 'Installing software-properties-common...'
-  sudo apt-get update && sudo apt-get install -y software-properties-common
+  sudo apt-get install -y software-properties-common
 fi
 

--- a/TFInstall.sh
+++ b/TFInstall.sh
@@ -6,6 +6,7 @@ then
 else
   echo "Terraform is not installed. Proceeding with installation."
 fi
+
 # Check if gnupg is installed
 if (which gpg)
 then
@@ -13,5 +14,13 @@ then
 else
   echo "Installing gnupg"
   sudo apt-get install -y gnupg
+fi
+
+# Check if software-properties-common is installed
+if dpkg -s software-properties-common > /dev/null 2>&1; then
+  echo 'software-properties-common is already installed'
+else
+  echo 'Installing software-properties-common...'
+  sudo apt-get update && sudo apt-get install -y software-properties-common
 fi
 

--- a/TFInstall.sh
+++ b/TFInstall.sh
@@ -1,0 +1,17 @@
+# Check if Terraform is installed
+if (which terraform)
+then
+  echo "Terraform is already installed."
+  exit 0
+else
+  echo "Terraform is not installed. Proceeding with installation."
+fi
+# Check if gnupg is installed
+if (which gpg)
+then
+  echo "gnupg is already installed."
+else
+  echo "Installing gnupg"
+  sudo apt-get install -y gnupg
+fi
+

--- a/TFInstall.sh
+++ b/TFInstall.sh
@@ -2,7 +2,6 @@
 if (which terraform)
 then
   echo "Terraform is already installed."
-  exit 0
 else
   echo "Terraform is not installed. Proceeding with installation."
 fi


### PR DESCRIPTION
Removed the exit code from the first code block because we want the script to run to the end, even if  TF is already installed because it should still complete all of the other checks. 